### PR TITLE
Skip chart type sheets when loading/parsing the spreadsheet

### DIFF
--- a/lib/src/gsheets.dart
+++ b/lib/src/gsheets.dart
@@ -162,6 +162,7 @@ class GSheets {
     final renderOption = _parseRenderOption(render);
     final inputOption = _parseInputOption(input);
     final sheets = (jsonDecode(response.body)['sheets'] as List)
+        .where((element) => !element.containsKey('charts'))
         .map((json) => Worksheet._fromJson(
               json,
               client,

--- a/lib/src/gsheets.dart
+++ b/lib/src/gsheets.dart
@@ -162,7 +162,7 @@ class GSheets {
     final renderOption = _parseRenderOption(render);
     final inputOption = _parseInputOption(input);
     final sheets = (jsonDecode(response.body)['sheets'] as List)
-        .where((element) => !element.containsKey('charts'))
+        .where((element) => element['properties']['sheetType'] == "GRID")
         .map((json) => Worksheet._fromJson(
               json,
               client,


### PR DESCRIPTION
If you have a sheet that is made up of a chart, it will have a different set of parameters than what the Worksheet factory expects and then fail on line 667 with a null reference exception:
      `sheetJson['properties']['gridProperties']['rowCount'],`
Chart type sheets will not have `gridProperties` at all.
I don't know if this is the best solution for the problem - we might want to load those sheets into the system, but for the fundamental features to work I think it's safe to skip those sheets from loading for the time being.