### PR TITLE
add sendNotificationEmails parameter to Future<Permission> share method

### DIFF
--- a/lib/src/gsheets.dart
+++ b/lib/src/gsheets.dart
@@ -752,6 +752,7 @@ class Spreadsheet {
   /// [type] - the account type.
   /// [role] - the primary role for this user.
   /// [withLink] - whether the link is required for this permission.
+  /// [sendNotificationEmails] - Whether to send notification emails when sharing to users or groups.
   ///
   /// Returns Future of shared [Permission].
   ///
@@ -762,9 +763,11 @@ class Spreadsheet {
     PermType type = PermType.user,
     PermRole role = PermRole.reader,
     bool withLink = false,
+    bool sendNotificationEmails = true,
   }) async {
     final response = await _client.post(
-      '$_filesEndpoint$id/permissions'.toUri(),
+      '$_filesEndpoint$id/permissions?sendNotificationEmails=${sendNotificationEmails ? 'true' : 'false'}'
+          .toUri(),
       body: jsonEncode({
         'value': user,
         'type': Permission._parseType(type),


### PR DESCRIPTION
Hello @a-marenkov

"Rate limit exceeded. User message: "Sorry, you have exceeded your sharing quota." exception occurs when run share method more 60times in a day.
A sharingRateLimitExceeded error occurs when the user has reached a sharing limit. This error is often linked with an email limit.
I added sendNotificationEmails boolean parameter to share method.

[problem link](https://stackoverflow.com/questions/62271877/gdrive-api-error-403-for-transferring-ownership-rate-limit-exceeded-user-messa)